### PR TITLE
Fix emote animation error when animation frames not specified

### DIFF
--- a/lib/ui/views/chat/widgets/emote_widget.dart
+++ b/lib/ui/views/chat/widgets/emote_widget.dart
@@ -66,7 +66,7 @@ class _AnimatedEmoteState extends State<_AnimatedEmote>
     );
     _animation = IntTween(
       begin: 0,
-      end: widget.emote.frames!.length * widget.emote.repeatCount!,
+      end: widget.emote.frames == null ? 0 : widget.emote.frames!.length * widget.emote.repeatCount!,
     ).animate(_controller);
     _controller.forward();
   }
@@ -78,8 +78,8 @@ class _AnimatedEmoteState extends State<_AnimatedEmote>
       builder: (_, __) {
         return SizedBox(
           height: widget.emoteHeight,
-          child: widget
-              .emote.frames![_animation.value % widget.emote.frames!.length],
+          child: widget.emote.frames != null ? widget
+              .emote.frames![_animation.value % widget.emote.frames!.length] : widget.emote.image,
         );
       },
     );


### PR DESCRIPTION
closes #8
This only substitutes animated emotes that can't be animated, with their static emote equivalent, so it's not a definitive solution.